### PR TITLE
Reduced I/O usage and CPU usage considerably.

### DIFF
--- a/SwtorCaster/Core/Domain/Log/CombatLogEvent.cs
+++ b/SwtorCaster/Core/Domain/Log/CombatLogEvent.cs
@@ -4,7 +4,6 @@ namespace SwtorCaster.Core.Domain.Log
 
     public class CombatLogEvent
     {
-        public string RawLine { get; set; }
         public DateTime TimeStamp { get; set; }
 
         public CombatLogParticipant Source { get; set; }

--- a/SwtorCaster/Core/Services/Parsing/CombatLogParser.cs
+++ b/SwtorCaster/Core/Services/Parsing/CombatLogParser.cs
@@ -38,7 +38,7 @@ namespace SwtorCaster.Core.Services.Parsing
             if (string.IsNullOrEmpty(line))
                 throw new ParseException("Line was null.");
 
-            CombatLogEvent = new CombatLogEvent() { RawLine = line };
+            CombatLogEvent = new CombatLogEvent();
 
             var match = BaseLineRegex.Match(line);
 


### PR DESCRIPTION
- Only checking for new files when the combat log directory is updated.
- Only trying to read the combat log file when it isn't at the end of
  the stream.
- Upped combat log file reader thread sleep time to 500ms. Combat log is
  only updated every 1.5 - 2 seconds so the difference isn't perceptible.
- Removed RawLine from CombatLogEvent. No reason for this to be here and
  take up a decent amount of memory. Combat log parser has a lot of
  opportunities for optimization.
